### PR TITLE
Add native file download support

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -39,8 +39,17 @@ jobs:
       - name: Build
         run: cmake --build build
 
-      - name: Run test suite
-        run: python -m unittest -v test.test_hf
+      - name: Run support tests
+        run: python -m unittest -v test.test_support
+
+      - name: Run CLI tests
+        run: python -m unittest -v test.test_cli
+
+      - name: Run HTTP tests
+        run: python -m unittest -v test.test_http
+
+      - name: Run transfer tests
+        run: python -m unittest -v test.test_transfer
 
   windows-cross-build:
     name: Windows cross-build (MinGW)

--- a/src/cli.c
+++ b/src/cli.c
@@ -67,11 +67,12 @@ void usage(const char *argv0) {
           "usage:\n"
           "  %s -d <server_path> [-p <port>]\n"
           "  %s -c <file_path> [-i <ip>] [-p <port>]\n"
+          "  %s -g <remote_file> [-o <local_path>] [-i <ip>] [-p <port>]\n"
           "  %s -m <message> [-i <ip>] [-p <port>]\n"
           "  %s status\n"
           "  %s stop\n"
           "  %s -q\n",
-          argv0, argv0, argv0, argv0, argv0, argv0);
+          argv0, argv0, argv0, argv0, argv0, argv0, argv0);
 }
 
 int parse_port(const char *s, uint16_t *out) {
@@ -97,6 +98,8 @@ parse_result_t parse_args(int argc, char **argv, Opt *opt) {
 
   opt->mode = init_mode;
   opt->path = NULL;
+  opt->remote_path = NULL;
+  opt->output_path = NULL;
   opt->message = NULL;
   opt->ip = "127.0.0.1";
   opt->port = 8888;
@@ -105,7 +108,9 @@ parse_result_t parse_args(int argc, char **argv, Opt *opt) {
 
   int seen_d = 0;
   int seen_c = 0;
+  int seen_g = 0;
   int seen_m = 0;
+  int seen_o = 0;
   int ip_set = 0;
   int control_mode_selected = 0;
   int mode_count = 0;
@@ -188,8 +193,30 @@ parse_result_t parse_args(int argc, char **argv, Opt *opt) {
         opt->mode = client_mode;
         opt->path = v;
         opt->message = NULL;
-        opt->msg_type = HF_MSG_TYPE_FILE_TRANSFER;
+        opt->msg_type = HF_MSG_TYPE_SEND_FILE;
         seen_c = 1;
+        break;
+      }
+
+      case 'g': {
+        const char *v = NULL;
+        if (control_mode_selected) {
+          fprintf(stderr, "control mode does not accept -g\n");
+          return PARSE_ERR;
+        }
+        if (seen_g) {
+          fprintf(stderr, "duplicate -g\n");
+          return PARSE_ERR;
+        }
+        if (need_value(argc, argv, &i, &v) != 0 || v[0] == '-') {
+          fprintf(stderr, "invalid remote file\n");
+          return PARSE_ERR;
+        }
+
+        opt->mode = client_mode;
+        opt->remote_path = v;
+        opt->msg_type = HF_MSG_TYPE_GET_FILE;
+        seen_g = 1;
         break;
       }
       
@@ -213,6 +240,26 @@ parse_result_t parse_args(int argc, char **argv, Opt *opt) {
         opt->message = v;
         opt->msg_type = HF_MSG_TYPE_TEXT_MESSAGE;
         seen_m = 1;
+        break;
+      }
+
+      case 'o': {
+        const char *v = NULL;
+        if (control_mode_selected) {
+          fprintf(stderr, "control mode does not accept -o\n");
+          return PARSE_ERR;
+        }
+        if (seen_o) {
+          fprintf(stderr, "duplicate -o\n");
+          return PARSE_ERR;
+        }
+        if (need_value(argc, argv, &i, &v) != 0 || v[0] == '-') {
+          fprintf(stderr, "invalid output path\n");
+          return PARSE_ERR;
+        }
+
+        opt->output_path = v;
+        seen_o = 1;
         break;
       }
 
@@ -251,25 +298,25 @@ parse_result_t parse_args(int argc, char **argv, Opt *opt) {
     }
   }
 
-  mode_count = seen_d + seen_c + seen_m + (control_mode_selected ? 1 : 0);
+  mode_count = seen_d + seen_c + seen_g + seen_m + (control_mode_selected ? 1 : 0);
+
+  if (seen_o && !seen_g) {
+    fprintf(stderr, "-o requires -g\n");
+    return PARSE_ERR;
+  }
 
   if (mode_count == 0) {
-    fprintf(stderr, "must specify one of -d, -c, -m, status, stop, or -q\n");
+    fprintf(stderr, "must specify one of -d, -c, -g, -m, status, stop, or -q\n");
     return PARSE_ERR;
   }
 
-  if (seen_d && seen_c) {
+  if (seen_d && (seen_c || seen_g || seen_m)) {
     fprintf(stderr, "cannot use server and client modes together\n");
     return PARSE_ERR;
   }
 
-  if (seen_d && seen_m) {
-    fprintf(stderr, "cannot use server and client modes together\n");
-    return PARSE_ERR;
-  }
-
-  if (seen_c && seen_m) {
-    fprintf(stderr, "cannot use -c -m together\n");
+  if ((seen_c + seen_g + seen_m) > 1) {
+    fprintf(stderr, "must choose exactly one client action: -c, -g, or -m\n");
     return PARSE_ERR;
   }
 
@@ -278,6 +325,7 @@ parse_result_t parse_args(int argc, char **argv, Opt *opt) {
   }
   if (opt->mode == server_mode && opt->path == NULL) return PARSE_ERR;
   if (opt->mode == client_mode && seen_c && opt->path == NULL) return PARSE_ERR;
+  if (opt->mode == client_mode && seen_g && opt->remote_path == NULL) return PARSE_ERR;
   if (opt->mode == client_mode && seen_m && opt->message == NULL) {
     return PARSE_ERR;
   }

--- a/src/cli.h
+++ b/src/cli.h
@@ -21,6 +21,8 @@ typedef enum {
 typedef struct {
   Mode mode;
   const char *path;
+  const char *remote_path;
+  const char *output_path;
   const char *message;
   const char *ip;
   uint16_t port;
@@ -29,7 +31,9 @@ typedef struct {
 } Opt;
 
 typedef struct {
-  const char *path; 
+  const char *path;
+  const char *remote_path;
+  const char *output_path;
   const char *message;
   const char *ip;
   uint16_t port;

--- a/src/client.c
+++ b/src/client.c
@@ -8,9 +8,16 @@
 #include <fcntl.h>
 #include <stddef.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include <sys/stat.h>
+
+#ifdef _WIN32
+  #include <process.h>
+#else
+  #include <unistd.h>
+#endif
 
 static const char *client_protocol_result_name(protocol_result_t res) {
   switch (res) {
@@ -28,6 +35,10 @@ static const char *client_protocol_result_name(protocol_result_t res) {
       return "invalid argument";
     case PROTOCOL_ERR_FILE_NAME_LEN:
       return "file name length";
+    case PROTOCOL_ERR_INVALID_FILE_NAME:
+      return "invalid file name";
+    case PROTOCOL_ERR_PAYLOAD_SIZE_MISMATCH:
+      return "payload size mismatch";
     case PROTOCOL_ERR_IO:
       return "io";
     case PROTOCOL_ERR_SHORT_WRITE:
@@ -214,6 +225,57 @@ static int client_send_file_body(int in, socket_t sock, uint64_t content_size) {
     fprintf(stderr, "invalid raw transfer arguments\n");
   } else {
     sock_perror("sendfile");
+  }
+
+  return 1;
+}
+
+static int client_open_temp_download(const char *final_path,
+                                     char *tmp_path,
+                                     size_t tmp_path_cap,
+                                     int *fd_out) {
+  int out = -1;
+
+  if (final_path == NULL || tmp_path == NULL || fd_out == NULL) {
+    return 1;
+  }
+
+#ifdef _WIN32
+  int pid = _getpid();
+#else
+  int pid = (int)getpid();
+#endif
+
+  for (int attempt = 0; attempt < 3; attempt++) {
+    if (fs_make_temp_path(tmp_path, tmp_path_cap, final_path, pid, attempt) != 0) {
+      return 1;
+    }
+    out = fs_open_temp_file(tmp_path);
+    if (out != -1) {
+      *fd_out = out;
+      return 0;
+    }
+    if (errno != EEXIST) {
+      return 1;
+    }
+  }
+
+  return 1;
+}
+
+static int client_recv_file_body(socket_t sock, int out_fd, uint64_t content_size) {
+  net_recv_file_result_t recv_res =
+    net_recv_file_best_effort(sock, out_fd, content_size);
+  if (recv_res == NET_RECV_FILE_OK) {
+    return 0;
+  }
+
+  if (recv_res == NET_RECV_FILE_EOF) {
+    fprintf(stderr, "server closed connection while sending file body\n");
+  } else if (recv_res == NET_RECV_FILE_INVALID_ARGUMENT) {
+    fprintf(stderr, "invalid download arguments\n");
+  } else {
+    sock_perror("recv(file_body)");
   }
 
   return 1;
@@ -437,6 +499,155 @@ CLEAN_UP:
   return exit_code;
 }
 
+static int client_get_file(const client_opt_t *opt) {
+  int exit_code = 0;
+  int out = -1;
+  socket_t sock;
+  socket_init(&sock);
+  const char *remote_path = opt->remote_path;
+  const char *output_path = opt->output_path;
+  char *offered_name = NULL;
+  uint64_t content_size = 0;
+  uint16_t remote_name_len = 0;
+  char tmp_path[4096];
+  protocol_result_t proto_res = PROTOCOL_OK;
+
+  tmp_path[0] = '\0';
+
+  if (remote_path == NULL || fs_validate_file_name(remote_path) != 0) {
+    fprintf(stderr, "invalid remote file\n");
+    return 1;
+  }
+  if (proto_get_file_name_len(remote_path, &remote_name_len) != 0) {
+    fprintf(stderr, "invalid remote file length\n");
+    return 1;
+  }
+
+  if (client_connect(opt->ip, opt->port, &sock) != 0) {
+    return 1;
+  }
+
+  {
+    protocol_header_t header = {0};
+    uint8_t header_buf[HF_PROTOCOL_HEADER_SIZE];
+    uint8_t request_buf[sizeof(uint16_t) + HF_PROTOCOL_MAX_FILE_NAME_LEN];
+
+    init_header(&header);
+    header.msg_type = HF_MSG_TYPE_GET_FILE;
+    header.flags = HF_MSG_FLAG_NONE;
+    header.payload_size = (uint64_t)proto_file_name_only_size(remote_name_len);
+
+    proto_res = encode_header(&header, header_buf);
+    if (proto_res != PROTOCOL_OK) {
+      fprintf(stderr, "failed to encode protocol header\n");
+      exit_code = 1;
+      goto CLEAN_UP;
+    }
+
+    proto_res = encode_file_name_only(remote_path, request_buf);
+    if (proto_res != PROTOCOL_OK) {
+      fprintf(stderr, "failed to encode get request\n");
+      exit_code = 1;
+      goto CLEAN_UP;
+    }
+
+    proto_res = send_header(sock, header_buf);
+    if (proto_res != PROTOCOL_OK) {
+      sock_perror("send_header");
+      exit_code = 1;
+      goto CLEAN_UP;
+    }
+
+    proto_res = proto_send_payload(
+      sock, request_buf, proto_file_name_only_size(remote_name_len));
+    if (proto_res != PROTOCOL_OK) {
+      sock_perror("send(get_request)");
+      exit_code = 1;
+      goto CLEAN_UP;
+    }
+  }
+
+  {
+    res_frame_t response = {0};
+    if (client_recv_response(sock, PROTO_PHASE_READY, "get", &response) != 0) {
+      exit_code = 1;
+      goto CLEAN_UP;
+    }
+    if (client_check_response(&response, PROTO_PHASE_READY, "get") != 0) {
+      exit_code = 1;
+      goto CLEAN_UP;
+    }
+  }
+
+  proto_res = proto_recv_file_transfer_prefix(sock, &offered_name, &content_size);
+  if (proto_res != PROTOCOL_OK) {
+    fprintf(stderr, "failed to receive file header: %s\n",
+            client_protocol_result_name(proto_res));
+    exit_code = 1;
+    goto CLEAN_UP;
+  }
+
+  if (output_path == NULL) {
+    if (fs_validate_file_name(offered_name) != 0) {
+      fprintf(stderr, "invalid offered file name\n");
+      exit_code = 1;
+      goto CLEAN_UP;
+    }
+    output_path = offered_name;
+  }
+
+  if (client_open_temp_download(output_path, tmp_path, sizeof(tmp_path), &out) != 0) {
+    perror("open(temp_download)");
+    exit_code = 1;
+    goto CLEAN_UP;
+  }
+
+  if (client_recv_file_body(sock, out, content_size) != 0) {
+    exit_code = 1;
+    goto CLEAN_UP;
+  }
+
+  if (fs_close(out) != 0) {
+    perror("close(temp_download)");
+    out = -1;
+    exit_code = 1;
+    goto CLEAN_UP;
+  }
+  out = -1;
+
+  {
+    res_frame_t response = {0};
+    if (client_recv_response(sock, PROTO_PHASE_FINAL, "get", &response) != 0) {
+      exit_code = 1;
+      goto CLEAN_UP;
+    }
+    if (client_check_response(&response, PROTO_PHASE_FINAL, "get") != 0) {
+      exit_code = 1;
+      goto CLEAN_UP;
+    }
+  }
+
+  if (fs_finalize_temp_file(tmp_path, output_path, NULL) != 0) {
+    perror("rename(download)");
+    exit_code = 1;
+    goto CLEAN_UP;
+  }
+  tmp_path[0] = '\0';
+
+CLEAN_UP:
+  if (out != -1) {
+    fs_close(out);
+  }
+  if (tmp_path[0] != '\0') {
+    fs_remove_quiet(tmp_path);
+  }
+  if (offered_name != NULL) {
+    free(offered_name);
+  }
+  socket_close(sock);
+  return exit_code;
+}
+
 int client(const client_opt_t *cli_opt) {
   if (cli_opt == NULL) {
     fprintf(stderr, "invalid client options\n");
@@ -444,10 +655,12 @@ int client(const client_opt_t *cli_opt) {
   }
 
   switch (cli_opt->msg_type) {
-    case HF_MSG_TYPE_FILE_TRANSFER:
+    case HF_MSG_TYPE_SEND_FILE:
       return client_send_file_raw(cli_opt);
     case HF_MSG_TYPE_TEXT_MESSAGE:
       return client_send_message(cli_opt);
+    case HF_MSG_TYPE_GET_FILE:
+      return client_get_file(cli_opt);
     default:
       fprintf(stderr, "unsupported client message type: %u\n",
               (unsigned)cli_opt->msg_type);

--- a/src/hfile.c
+++ b/src/hfile.c
@@ -16,6 +16,8 @@ static inline void init_server_opt(const Opt *opt, server_opt_t *server_opt) {
 
 static inline void init_client_opt(const Opt *opt, client_opt_t *client_opt) {
   client_opt->path = opt->path;
+  client_opt->remote_path = opt->remote_path;
+  client_opt->output_path = opt->output_path;
   client_opt->message = opt->message;
   client_opt->ip = opt->ip;
   client_opt->port = opt->port;

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -114,8 +114,30 @@ int proto_get_file_name_len(const char *file_name, uint16_t *out_len) {
   return 0;
 }
 
+size_t proto_file_name_only_size(uint16_t file_name_len) {
+  return sizeof(uint16_t) + (size_t)file_name_len;
+}
+
 size_t proto_file_transfer_prefix_size(uint16_t file_name_len) {
-  return sizeof(uint16_t) + (size_t)file_name_len + sizeof(uint64_t);
+  return proto_file_name_only_size(file_name_len) + sizeof(uint64_t);
+}
+
+protocol_result_t encode_file_name_only(const char *file_name, uint8_t *out) {
+  uint16_t file_name_len = 0;
+  uint16_t net_len = 0;
+
+  if (out == NULL) {
+    return PROTOCOL_ERR_INVALID_ARGUMENT;
+  }
+  if (proto_get_file_name_len(file_name, &file_name_len) != 0) {
+    return PROTOCOL_ERR_FILE_NAME_LEN;
+  }
+
+  net_len = htons(file_name_len);
+  memcpy(out, &net_len, sizeof(net_len));
+  out += sizeof(net_len);
+  memcpy(out, file_name, (size_t)file_name_len);
+  return PROTOCOL_OK;
 }
 
 protocol_result_t encode_file_prefix(const char *file_name,
@@ -134,17 +156,13 @@ protocol_result_t encode_file_prefix(const char *file_name,
   net_len = htons(file_name_len);
   memcpy(out, &net_len, sizeof(net_len));
   out += sizeof(net_len);
-
   memcpy(out, file_name, (size_t)file_name_len);
   out += file_name_len;
-
   encode_u64_be(content_size, out);
   return PROTOCOL_OK;
 }
 
-protocol_result_t proto_send_file_transfer_prefix(socket_t sock,
-                                                  const uint8_t *in,
-                                                  size_t len) {
+protocol_result_t proto_send_payload(socket_t sock, const uint8_t *in, size_t len) {
   ssize_t n = 0;
 
   if (is_socket_invalid(sock) || in == NULL) {
@@ -162,22 +180,25 @@ protocol_result_t proto_send_file_transfer_prefix(socket_t sock,
   return PROTOCOL_OK;
 }
 
-protocol_result_t proto_recv_file_transfer_prefix(socket_t sock,
-                                                      char **file_name_out,
-                                                      uint64_t *content_size_out) {
+protocol_result_t proto_send_file_transfer_prefix(socket_t sock,
+                                                  const uint8_t *in,
+                                                  size_t len) {
+  return proto_send_payload(sock, in, len);
+}
+
+protocol_result_t proto_recv_file_name_only(socket_t sock, char **file_name_out) {
   uint16_t net_len = 0;
   uint16_t file_name_len = 0;
   char *file_name = NULL;
-  uint8_t szbuf[8];
+  ssize_t n = 0;
 
-  if (file_name_out == NULL || content_size_out == NULL) {
+  if (file_name_out == NULL) {
     return PROTOCOL_ERR_INVALID_ARGUMENT;
   }
 
   *file_name_out = NULL;
-  *content_size_out = 0;
 
-  ssize_t n = recv_all(sock, &net_len, sizeof(net_len));
+  n = recv_all(sock, &net_len, sizeof(net_len));
   if (n != (ssize_t)sizeof(net_len)) {
     return n < 0 ? PROTOCOL_ERR_IO : PROTOCOL_ERR_EOF;
   }
@@ -197,7 +218,31 @@ protocol_result_t proto_recv_file_transfer_prefix(socket_t sock,
     free(file_name);
     return n < 0 ? PROTOCOL_ERR_IO : PROTOCOL_ERR_EOF;
   }
+
   file_name[file_name_len] = '\0';
+  *file_name_out = file_name;
+  return PROTOCOL_OK;
+}
+
+protocol_result_t proto_recv_file_transfer_prefix(socket_t sock,
+                                                  char **file_name_out,
+                                                  uint64_t *content_size_out) {
+  char *file_name = NULL;
+  uint8_t szbuf[8];
+  ssize_t n = 0;
+  protocol_result_t res = PROTOCOL_OK;
+
+  if (file_name_out == NULL || content_size_out == NULL) {
+    return PROTOCOL_ERR_INVALID_ARGUMENT;
+  }
+
+  *file_name_out = NULL;
+  *content_size_out = 0;
+
+  res = proto_recv_file_name_only(sock, &file_name);
+  if (res != PROTOCOL_OK) {
+    return res;
+  }
 
   n = recv_all(sock, szbuf, sizeof(szbuf));
   if (n != (ssize_t)sizeof(szbuf)) {
@@ -266,7 +311,8 @@ protocol_result_t decode_header(protocol_header_t *header, const uint8_t *in) {
   
   header->msg_type = *base++;
   if (header->msg_type != HF_MSG_TYPE_TEXT_MESSAGE &&
-      header->msg_type != HF_MSG_TYPE_FILE_TRANSFER) {
+      header->msg_type != HF_MSG_TYPE_SEND_FILE &&
+      header->msg_type != HF_MSG_TYPE_GET_FILE) {
     return PROTOCOL_ERR_HEADER_MSG_TYPE;
   }
   

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -15,8 +15,9 @@
 #define HF_PROTOCOL_MAGIC 0x0429u
 #define HF_PROTOCOL_VERSION 0x03u
 
-#define HF_MSG_TYPE_FILE_TRANSFER 0x01u
+#define HF_MSG_TYPE_SEND_FILE 0x01u
 #define HF_MSG_TYPE_TEXT_MESSAGE 0x02u
+#define HF_MSG_TYPE_GET_FILE 0x03u
 
 #define HF_MSG_FLAG_NONE 0x00u
 
@@ -80,13 +81,20 @@ protocol_result_t recv_res_frame(socket_t sock, res_frame_t *frame);
 
 
 int proto_get_file_name_len(const char *file_name, uint16_t *out_len);
+size_t proto_file_name_only_size(uint16_t file_name_len);
 size_t proto_file_transfer_prefix_size(uint16_t file_name_len);
+protocol_result_t encode_file_name_only(const char *file_name, uint8_t *out);
 protocol_result_t encode_file_prefix(const char *file_name,
                                      uint64_t content_size,
                                      uint8_t *out);
+protocol_result_t proto_send_payload(socket_t sock,
+                                     const uint8_t *in,
+                                     size_t len);
 protocol_result_t proto_send_file_transfer_prefix(socket_t sock,
                                                   const uint8_t *in,
                                                   size_t len);
+protocol_result_t proto_recv_file_name_only(socket_t sock,
+                                            char **file_name_out);
 protocol_result_t proto_recv_file_transfer_prefix(socket_t sock,
                                                        char **file_name_out,
                                                        uint64_t *content_size_out);

--- a/src/server.c
+++ b/src/server.c
@@ -86,6 +86,10 @@ static protocol_result_t server_handle_file_transfer(
   socket_t conn,
   const server_opt_t *ser_opt,
   const protocol_header_t *proto_header);
+static protocol_result_t server_handle_get_file(
+  socket_t conn,
+  const server_opt_t *ser_opt,
+  const protocol_header_t *proto_header);
 static protocol_result_t server_send_response(socket_t conn,
                                               uint8_t phase,
                                               uint8_t status,
@@ -449,8 +453,11 @@ static int server_handle_protocol_connection(socket_t conn,
     case HF_MSG_TYPE_TEXT_MESSAGE:
       return server_handle_text_message(conn, &proto_header);
 
-    case HF_MSG_TYPE_FILE_TRANSFER:
+    case HF_MSG_TYPE_SEND_FILE:
       return server_handle_file_transfer(conn, ser_opt, &proto_header) == PROTOCOL_OK ? 0 : 1;
+
+    case HF_MSG_TYPE_GET_FILE:
+      return server_handle_get_file(conn, ser_opt, &proto_header) == PROTOCOL_OK ? 0 : 1;
 
     default:
       fprintf(stderr, "protocol error: unsupported message type: %u\n",
@@ -704,6 +711,139 @@ SEND_READY_REJECT:
 
 CLEANUP:
   if (file_name != NULL) free(file_name);
+  return result;
+}
+
+static protocol_result_t server_handle_get_file(
+  socket_t conn,
+  const server_opt_t *ser_opt,
+  const protocol_header_t *proto_header) {
+  char *file_name = NULL;
+  char full_path[4096];
+  fs_path_info_t info = {0};
+  int fd = -1;
+  protocol_result_t result = PROTOCOL_ERR_IO;
+
+  if (ser_opt == NULL) {
+    fprintf(stderr, "invalid get handler arguments\n");
+    return PROTOCOL_ERR_INVALID_ARGUMENT;
+  }
+
+  if (proto_header->payload_size < (uint64_t)proto_file_name_only_size(1)) {
+    fprintf(stderr, "protocol error: get payload size too small\n");
+    (void)server_send_response(
+      conn, PROTO_PHASE_READY, PROTO_STATUS_REJECTED, PROTOCOL_ERR_INVALID_ARGUMENT);
+    return PROTOCOL_ERR_INVALID_ARGUMENT;
+  }
+
+  result = proto_recv_file_name_only(conn, &file_name);
+  if (result != PROTOCOL_OK) {
+    if (result == PROTOCOL_ERR_FILE_NAME_LEN) {
+      fprintf(stderr, "protocol error: invalid get file name length\n");
+    } else if (result == PROTOCOL_ERR_ALLOC) {
+      perror("malloc(file_name)");
+    } else if (result == PROTOCOL_ERR_EOF) {
+      fprintf(stderr, "protocol error: unexpected EOF while receiving get request\n");
+    } else {
+      sock_perror("proto_recv_file_name_only");
+    }
+    goto CLEANUP;
+  }
+
+  if (fs_validate_file_name(file_name) != 0) {
+    fprintf(stderr, "invalid get file name: %s\n", file_name);
+    result = PROTOCOL_ERR_INVALID_FILE_NAME;
+    goto SEND_READY_REJECT;
+  }
+
+  if (proto_header->payload_size !=
+      (uint64_t)proto_file_name_only_size((uint16_t)strlen(file_name))) {
+    fprintf(stderr, "protocol error: get payload size mismatch\n");
+    result = PROTOCOL_ERR_PAYLOAD_SIZE_MISMATCH;
+    goto SEND_READY_REJECT;
+  }
+
+  if (fs_join_path(full_path, sizeof(full_path), ser_opt->path, file_name) != 0) {
+    fprintf(stderr, "output path is too long\n");
+    result = PROTOCOL_ERR_INVALID_ARGUMENT;
+    goto SEND_READY_REJECT;
+  }
+
+  if (fs_get_path_info(full_path, &info) != 0 || info.kind != FS_PATH_KIND_FILE) {
+    result = PROTOCOL_ERR_INVALID_ARGUMENT;
+    goto SEND_READY_REJECT;
+  }
+
+#ifdef _WIN32
+  fd = fs_open(full_path, O_RDONLY | O_BINARY, 0);
+#else
+  fd = fs_open(full_path, O_RDONLY, 0);
+#endif
+  if (fd == -1) {
+    result = PROTOCOL_ERR_IO;
+    goto SEND_READY_REJECT;
+  }
+
+  result = server_send_response(
+    conn, PROTO_PHASE_READY, PROTO_STATUS_OK, PROTOCOL_OK);
+  if (result != PROTOCOL_OK) {
+    sock_perror("send_res_frame(get_ready)");
+    goto CLEANUP;
+  }
+
+  {
+    uint8_t prefix_buf[sizeof(uint16_t) + HF_PROTOCOL_MAX_FILE_NAME_LEN + sizeof(uint64_t)];
+    result = encode_file_prefix(file_name, info.size, prefix_buf);
+    if (result != PROTOCOL_OK) {
+      goto SEND_FINAL_FAILED;
+    }
+    result = proto_send_payload(
+      conn,
+      prefix_buf,
+      proto_file_transfer_prefix_size((uint16_t)strlen(file_name)));
+    if (result != PROTOCOL_OK) {
+      goto CLEANUP;
+    }
+  }
+
+  {
+    net_send_file_result_t send_res = net_send_file_best_effort(conn, fd, info.size);
+    if (send_res != NET_SEND_FILE_OK) {
+      result = PROTOCOL_ERR_IO;
+      goto SEND_FINAL_FAILED;
+    }
+  }
+
+  result = server_send_response(
+    conn, PROTO_PHASE_FINAL, PROTO_STATUS_OK, PROTOCOL_OK);
+  if (result != PROTOCOL_OK) {
+    sock_perror("send_res_frame(get_final_ok)");
+    goto CLEANUP;
+  }
+
+  result = PROTOCOL_OK;
+  goto CLEANUP;
+
+SEND_FINAL_FAILED:
+  if (server_send_response(
+        conn, PROTO_PHASE_FINAL, PROTO_STATUS_FAILED, result) != PROTOCOL_OK) {
+    sock_perror("send_res_frame(get_final_failed)");
+  }
+  goto CLEANUP;
+
+SEND_READY_REJECT:
+  if (server_send_response(
+        conn, PROTO_PHASE_READY, PROTO_STATUS_REJECTED, result) != PROTOCOL_OK) {
+    sock_perror("send_res_frame(get_ready_rejected)");
+  }
+
+CLEANUP:
+  if (fd != -1) {
+    fs_close(fd);
+  }
+  if (file_name != NULL) {
+    free(file_name);
+  }
   return result;
 }
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -35,7 +35,7 @@ class TestCLI(unittest.TestCase):
                 "args": [],
                 "rc": 1,
                 "stderr_contains": [
-                    "must specify one of -d, -c, -m, status, stop, or -q",
+                    "must specify one of -d, -c, -g, -m, status, stop, or -q",
                     "usage:",
                 ],
             },
@@ -82,6 +82,15 @@ class TestCLI(unittest.TestCase):
                 "stderr_contains": ["control mode does not accept -p", "usage:"],
             },
             {
+                "name": "put_and_get",
+                "args": ["-c", "in", "-g", "out"],
+                "rc": 1,
+                "stderr_contains": [
+                    "must choose exactly one client action: -c, -g, or -m",
+                    "usage:",
+                ],
+            },
+            {
                 "name": "server_has_i",
                 "args": ["-d", "out", "-i", "127.0.0.1"],
                 "rc": 1,
@@ -98,6 +107,12 @@ class TestCLI(unittest.TestCase):
                 "args": ["-d", "out", "-p", "nope"],
                 "rc": 1,
                 "stderr_contains": ["invalid port", "usage:"],
+            },
+            {
+                "name": "output_requires_get",
+                "args": ["-o", "out.txt"],
+                "rc": 1,
+                "stderr_contains": ["-o requires -g", "usage:"],
             },
         ]
 
@@ -145,6 +160,15 @@ class TestCLI(unittest.TestCase):
             f"argv={r.argv} stdout={r.stdout!r} stderr={r.stderr!r}",
         )
         self.assertIn("open", r.stderr)
+
+    def test_get_rejects_invalid_remote_file(self) -> None:
+        r = run_hf(self.hf_path, ["-g", "../bad"], timeout=5.0)
+        self.assertEqual(
+            r.returncode,
+            1,
+            f"argv={r.argv} stdout={r.stdout!r} stderr={r.stderr!r}",
+        )
+        self.assertIn("invalid remote file", r.stderr)
 
     def test_qr_requires_running_daemon(self) -> None:
         run_hf(self.hf_path, ["stop"], timeout=5.0)

--- a/test/test_support.py
+++ b/test/test_support.py
@@ -35,6 +35,7 @@ class TestSupport(unittest.TestCase):
         self.assertEqual(protocol_define("HF_PROTOCOL_MAGIC"), 0x0429)
         self.assertGreater(protocol_define("HF_PROTOCOL_VERSION"), 0)
         self.assertEqual(protocol_define("HF_MSG_FLAG_NONE"), 0x00)
+        self.assertEqual(protocol_define("HF_MSG_TYPE_GET_FILE"), 0x03)
         self.assertEqual(
             protocol_define("HF_PROTOCOL_MAX_TEXT_MESSAGE_SIZE"), 256 * 1024
         )

--- a/test/test_transfer.py
+++ b/test/test_transfer.py
@@ -5,6 +5,7 @@ import signal
 import shutil
 import socket
 import struct
+import threading
 import time
 import unittest
 from pathlib import Path
@@ -14,6 +15,7 @@ from test.support.hf import (
     assert_files_equal,
     make_temp_dir,
     protocol_define,
+    reserve_free_port,
     resolve_hf_path,
     run_hf,
     tail_text_file,
@@ -25,11 +27,93 @@ from test.support.hf import (
 CHUNK_SIZE = 1024 * 1024
 PROTOCOL_MAGIC = protocol_define("HF_PROTOCOL_MAGIC")
 PROTOCOL_VERSION = protocol_define("HF_PROTOCOL_VERSION")
-MSG_TYPE_FILE_TRANSFER = protocol_define("HF_MSG_TYPE_FILE_TRANSFER")
+MSG_TYPE_SEND_FILE = protocol_define("HF_MSG_TYPE_SEND_FILE")
 MSG_TYPE_TEXT_MESSAGE = protocol_define("HF_MSG_TYPE_TEXT_MESSAGE")
 MSG_FLAG_NONE = protocol_define("HF_MSG_FLAG_NONE")
 MAX_TEXT_MESSAGE_SIZE = protocol_define("HF_PROTOCOL_MAX_TEXT_MESSAGE_SIZE")
 FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "transfer"
+
+
+class FakeDownloadServer:
+    def __init__(
+        self,
+        *,
+        offered_name: bytes,
+        body: bytes,
+        final_frame: bytes | None,
+        host: str = "127.0.0.1",
+    ) -> None:
+        self.host = host
+        self.port = reserve_free_port(host=host)
+        self.offered_name = offered_name
+        self.body = body
+        self.final_frame = final_frame
+        self._listener: socket.socket | None = None
+        self._thread: threading.Thread | None = None
+        self._ready = threading.Event()
+        self._error: BaseException | None = None
+
+    def start(self) -> None:
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+        if not self._ready.wait(timeout=5.0):
+            raise RuntimeError("fake download server did not start")
+
+    def stop(self) -> None:
+        if self._listener is not None:
+            try:
+                self._listener.close()
+            except OSError:
+                pass
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
+        if self._error is not None:
+            raise RuntimeError(f"fake download server failed: {self._error}")
+
+    def _recv_exact(self, conn: socket.socket, size: int) -> bytes:
+        chunks: list[bytes] = []
+        remaining = size
+        while remaining > 0:
+            chunk = conn.recv(remaining)
+            if not chunk:
+                raise RuntimeError("client closed connection early")
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        return b"".join(chunks)
+
+    def _serve(self) -> None:
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._listener = listener
+        try:
+            listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            listener.bind((self.host, self.port))
+            listener.listen(1)
+            self._ready.set()
+            conn, _ = listener.accept()
+            with conn:
+                header = self._recv_exact(conn, 13)
+                payload_size = struct.unpack("!HBBBQ", header)[4]
+                if payload_size > 0:
+                    self._recv_exact(conn, payload_size)
+
+                conn.sendall(struct.pack("!BBH", 0, 0, 0))
+                conn.sendall(
+                    struct.pack("!H", len(self.offered_name))
+                    + self.offered_name
+                    + struct.pack("!Q", len(self.body))
+                )
+                if self.body:
+                    conn.sendall(self.body)
+                if self.final_frame is not None:
+                    conn.sendall(self.final_frame)
+        except BaseException as e:
+            self._error = e
+            self._ready.set()
+        finally:
+            try:
+                listener.close()
+            except OSError:
+                pass
 
 
 class TransferTestCase(unittest.TestCase):
@@ -44,8 +128,10 @@ class TransferTestCase(unittest.TestCase):
         cls.base_dir = Path(cls._tmp.name)
         cls.in_dir = cls.base_dir / "inputs"
         cls.out_dir = cls.base_dir / "outputs"
+        cls.download_dir = cls.base_dir / "downloads"
         cls.in_dir.mkdir(parents=True, exist_ok=True)
         cls.out_dir.mkdir(parents=True, exist_ok=True)
+        cls.download_dir.mkdir(parents=True, exist_ok=True)
 
         cls.server = HFileServer(hf_path=cls.hf_path, out_dir=cls.out_dir)
         cls.server.start(startup_timeout=5.0)
@@ -346,6 +432,134 @@ class TestTransferCLI(TransferTestCase):
         self.assertFalse(dst.exists(), f"unexpected output file: {dst}")
         self._assert_no_temp_files(src.name)
 
+    def test_get_downloads_uploaded_file(self) -> None:
+        src = self._write_input_file("download.txt", b"download me\n")
+        self._send_and_assert_ok(src)
+
+        download_dst = self.download_dir / "download-copy.txt"
+        self._reset_output_path(download_dst)
+
+        r = run_hf(
+            self.hf_path,
+            [
+                "-g",
+                src.name,
+                "-o",
+                download_dst,
+                "-i",
+                self.server.host,
+                "-p",
+                str(self.server.port),
+            ],
+            timeout=8.0,
+        )
+
+        self.assertEqual(
+            r.returncode,
+            0,
+            f"client failed argv={r.argv} stdout={r.stdout!r} stderr={r.stderr!r}",
+        )
+        self.assertTrue(
+            wait_for_file_stable(download_dst, timeout=5.0),
+            f"download not saved: {download_dst}; stderr={r.stderr!r}",
+        )
+        assert_files_equal(self, src, download_dst)
+
+    def test_get_rejects_missing_remote_file(self) -> None:
+        download_dst = self.download_dir / "missing.txt"
+        self._reset_output_path(download_dst)
+
+        r = run_hf(
+            self.hf_path,
+            [
+                "-g",
+                "missing.txt",
+                "-o",
+                download_dst,
+                "-i",
+                self.server.host,
+                "-p",
+                str(self.server.port),
+            ],
+            timeout=8.0,
+        )
+
+        self.assertEqual(
+            r.returncode,
+            1,
+            f"client failed argv={r.argv} stdout={r.stdout!r} stderr={r.stderr!r}",
+        )
+        self.assertIn("server reported get failure", r.stderr)
+        self.assertFalse(download_dst.exists())
+
+    def test_get_rejects_invalid_offered_name(self) -> None:
+        server = FakeDownloadServer(
+            offered_name=b"../escape.txt",
+            body=b"",
+            final_frame=None,
+        )
+        server.start()
+        try:
+            escaped_path = self.base_dir / "escape.txt"
+            self._reset_output_path(escaped_path)
+
+            r = run_hf(
+                self.hf_path,
+                ["-g", "download.txt", "-i", server.host, "-p", str(server.port)],
+                cwd=self.download_dir,
+                timeout=8.0,
+            )
+        finally:
+            server.stop()
+
+        self.assertEqual(
+            r.returncode,
+            1,
+            f"client failed argv={r.argv} stdout={r.stdout!r} stderr={r.stderr!r}",
+        )
+        self.assertIn("invalid offered file name", r.stderr)
+        self.assertFalse(escaped_path.exists())
+
+    def test_get_does_not_publish_file_when_final_fails(self) -> None:
+        download_dst = self.download_dir / "final-failed.txt"
+        self._reset_output_path(download_dst)
+
+        server = FakeDownloadServer(
+            offered_name=b"server.txt",
+            body=b"body before final failure\n",
+            final_frame=self._make_res_frame(1, 2, 9),
+        )
+        server.start()
+        try:
+            r = run_hf(
+                self.hf_path,
+                [
+                    "-g",
+                    "server.txt",
+                    "-o",
+                    download_dst,
+                    "-i",
+                    server.host,
+                    "-p",
+                    str(server.port),
+                ],
+                timeout=8.0,
+            )
+        finally:
+            server.stop()
+
+        self.assertEqual(
+            r.returncode,
+            1,
+            f"client failed argv={r.argv} stdout={r.stdout!r} stderr={r.stderr!r}",
+        )
+        self.assertIn("server reported get failure", r.stderr)
+        self.assertFalse(download_dst.exists())
+        self.assertFalse(
+            list(self.download_dir.glob(f"{download_dst.name}.tmp.*")),
+            "unexpected temp download files left behind",
+        )
+
     def test_fixtures(self) -> None:
         if not FIXTURES_DIR.exists():
             self.skipTest(f"fixtures dir not found: {FIXTURES_DIR}")
@@ -407,7 +621,7 @@ class TestTransferProtocol(TransferTestCase):
 
     def test_file_protocol_rejects_payload_size_too_small(self) -> None:
         header = self._make_header(
-            msg_type=MSG_TYPE_FILE_TRANSFER,
+            msg_type=MSG_TYPE_SEND_FILE,
             payload_size=9,
         )
 
@@ -475,7 +689,7 @@ class TestTransferProtocol(TransferTestCase):
         content_size = 1024
         prefix = self._make_file_prefix(file_name, content_size)
         header = self._make_header(
-            msg_type=MSG_TYPE_FILE_TRANSFER,
+            msg_type=MSG_TYPE_SEND_FILE,
             payload_size=len(prefix) + content_size,
         )
 
@@ -497,7 +711,7 @@ class TestTransferProtocol(TransferTestCase):
         content_size = 2
         prefix = self._make_file_prefix(file_name, content_size)
         header = self._make_header(
-            msg_type=MSG_TYPE_FILE_TRANSFER,
+            msg_type=MSG_TYPE_SEND_FILE,
             payload_size=len(prefix) + content_size + 1,
         )
 
@@ -518,7 +732,7 @@ class TestTransferProtocol(TransferTestCase):
         body = b"raw success\n"
         prefix = self._make_file_prefix(file_name, len(body))
         header = self._make_header(
-            msg_type=MSG_TYPE_FILE_TRANSFER,
+            msg_type=MSG_TYPE_SEND_FILE,
             payload_size=len(prefix) + len(body),
         )
 
@@ -563,7 +777,7 @@ class TestTransferProtocol(TransferTestCase):
         body = b""
         prefix = self._make_file_prefix(file_name, len(body))
         header = self._make_header(
-            msg_type=MSG_TYPE_FILE_TRANSFER,
+            msg_type=MSG_TYPE_SEND_FILE,
             payload_size=len(prefix) + len(body),
         )
 
@@ -593,7 +807,7 @@ class TestTransferProtocol(TransferTestCase):
         content_size = 1024
         prefix = self._make_file_prefix(file_name, content_size)
         header = self._make_header(
-            msg_type=MSG_TYPE_FILE_TRANSFER,
+            msg_type=MSG_TYPE_SEND_FILE,
             payload_size=len(prefix) + content_size,
         )
 


### PR DESCRIPTION
## Summary
- add native protocol support for client-side file downloads via `hf -g`
- rename the send-file message type to `HF_MSG_TYPE_SEND_FILE` and cover download edge cases
- split CI unittest execution into separate support, CLI, HTTP, and transfer steps

## Testing
- `./build.sh`
- `python3 -m unittest -v test.test_cli test.test_transfer`
- `python3 -m unittest -v test.test_cli.TestCLI.test_get_rejects_invalid_remote_file test.test_transfer.TestTransferCLI.test_get_downloads_uploaded_file test.test_transfer.TestTransferCLI.test_get_rejects_invalid_offered_name test.test_transfer.TestTransferCLI.test_get_does_not_publish_file_when_final_fails`